### PR TITLE
feat: Change parent route path from "/" to "*"

### DIFF
--- a/friendster-frontend/vite-project/src/App.jsx
+++ b/friendster-frontend/vite-project/src/App.jsx
@@ -1,23 +1,21 @@
-import React from "react";
-import './App.css'
-import  Navbar  from "./components/Navbar"
-import Footer from "./components/Footer"
-import { Routes, Route } from 'react-router-dom';
-import  Home  from './pages/Home';
-import  Results  from './pages/Results';
-
+import "./App.css";
+import Navbar from "./components/Navbar";
+import Footer from "./components/Footer";
+import { Routes, Route } from "react-router-dom";
+import Home from "./pages/Home";
+import Results from "./pages/Results";
 
 function App() {
   return (
-      <div className = "App">
-        <Navbar/>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/Results" element={<Results />} />
-        </Routes>
-        <Footer/>
-      </div>
+    <div className='App'>
+      <Navbar />
+      <Routes>
+        <Route path='*' element={<Home />} />
+        <Route path='/Results' element={<Results />} />
+      </Routes>
+      <Footer />
+    </div>
   );
 }
 
-export default App
+export default App;

--- a/friendster-frontend/vite-project/src/pages/Home.jsx
+++ b/friendster-frontend/vite-project/src/pages/Home.jsx
@@ -1,16 +1,15 @@
-import React from 'react';
-import { Route, Routes } from 'react-router-dom';
-import Banner from '../components/Banner'
-import Events from '../components/Events'
-import EventDetail from '../components/EventDetail';
+import { Route, Routes } from "react-router-dom";
+import Banner from "../components/Banner";
+import Events from "../components/Events";
+import EventDetail from "../components/EventDetail";
 
 function Home() {
   return (
-    <div className = "home">
-      <Banner/>
+    <div className='home'>
+      <Banner />
       <Routes>
-      <Route exact path="/*" element={<Events />} />
-      <Route exact path="/events/:id" element={<EventDetail />} />
+        <Route exact path='/' element={<Events />} />
+        <Route exact path='/events/:id' element={<EventDetail />} />
       </Routes>
     </div>
   );


### PR DESCRIPTION
This addresses the warning regarding descendant <Routes> under a parent <Route> with an inadequate path. To ensure proper route matching, the parent <Route> path has been updated to include a trailing asterisk "*".

Fixes: #13 